### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Atom allows some editor specific settings which can now manually be added to the
 The settings currently available are `setSoftTabs`, `setSoftWrap`and `setTabLength`. After making a change to the settings they can be updated by searching for **Reload Project Settings** under the Command Palette `cmd-shift-p`
 
 ```CoffeeScript
-'Project Manager:'
+'Project Manager':
   'title': 'Project Manager'
   'paths': [
     '/path/to/project-manager'


### PR DESCRIPTION
I just copied your example config, and everything exploded! Took me about 10 minutes to realize it was because the colon was inside the quote. Figured I'd submit a patch to save future peoples the same pain.
