### PR TITLE
View, edit and enforce project settings.

### DIFF
--- a/lib/project-manager-view.coffee
+++ b/lib/project-manager-view.coffee
@@ -60,4 +60,3 @@ class ProjectManagerView extends SelectListView
   sortBy: (arr, key) ->
     arr.sort (a, b) ->
       a[key].toUpperCase() > b[key].toUpperCase()
-

--- a/lib/settings/project-path-view.coffee
+++ b/lib/settings/project-path-view.coffee
@@ -1,0 +1,10 @@
+{$, $$, View, EditorView} = require 'atom'
+
+module.exports =
+class ProjectPathView extends View
+  @content: ->
+    @div =>
+      @subview 'pathField', new EditorView(mini: true)
+
+  initialize: (path) ->
+    @pathField.setText(path)

--- a/lib/settings/project-setting-view.coffee
+++ b/lib/settings/project-setting-view.coffee
@@ -1,0 +1,23 @@
+{$, $$, View, EditorView} = require 'atom'
+
+module.exports =
+class ProjectSettingView extends View
+  @content: ->
+    @div class: 'row', =>
+      @div class: 'col-lg-6', =>
+        @subview 'settingNameEditor', new EditorView({ mini: true })
+      @div class: 'col-lg-6', =>
+        @div class: 'input-group', =>
+          @subview 'settingValueEditor', new EditorView({ mini: true })
+          @div class: 'input-group-btn', =>
+            @button class: 'btn btn-default', outlet: 'removePathButton', =>
+              @span class: 'icon icon-dash'
+
+  initialize: ({settingName, settingValue}) ->
+    @settingNameEditor.setPlaceholderText('package-name.settingName')
+    @settingValueEditor.setPlaceholderText('right, true, 1, eggs ...')
+    @settingNameEditor.setText(settingName) if settingName
+    @settingValueEditor.setText(settingValue) if settingValue
+
+    @removePathButton.on 'click', =>
+      @parent().view().removeSetting(@)

--- a/lib/settings/project-view.coffee
+++ b/lib/settings/project-view.coffee
@@ -1,0 +1,66 @@
+{$, $$, View, EditorView} = require 'atom'
+
+PathView = require './project-path-view'
+SettingView = require './project-setting-view'
+
+module.exports =
+class View extends View
+  @content: ({settings}) ->
+    @section class: 'project-manager-settings-project-view inset-panel', =>
+      @div class: 'panel-heading', =>
+        @subview 'projectTitle', new EditorView({mini: true})
+      @div class: 'panel-body', =>
+        @div outlet: 'pathsList'
+        @div class: 'project-settings-panel inset-panel padded', =>
+          @div class: 'panel-heading icon icon-gear', =>
+            @span 'Settings'
+          @div class: 'panel-body', =>
+            @div outlet: 'projectSettingsList'
+            @button 'Add Setting', class: 'icon icon-plus btn btn-default add-project-setting', outlet: 'addSettingButton'
+
+  initialize: ({@project}) ->
+    {title, paths, settings} = @project
+    settings ||= {}
+    @projectTitle.setText(title)
+    @pathViews = []
+    @settingViews = []
+    for path in paths
+      @appendPath(path)
+    @addSettingButton.on 'click', => @appendSetting()
+    for settingName, settingValue of @project.settings
+      @appendSetting(settingName, settingValue)
+    @appendSetting()
+
+  removeSetting: (view) ->
+    index = @settingViews.indexOf(view)
+    @settingViews.splice(index, 1)
+    view.remove()
+    @parent().view().saveProjects()
+
+  appendPath: (path) ->
+    pathView = new PathView(path)
+    @pathViews.push(pathView)
+    @pathsList.append(pathView)
+    PathView
+
+  appendSetting: (name, value) ->
+    settingView = new SettingView(settingName: name, settingValue: value)
+    @settingViews.push(settingView)
+    @projectSettingsList.append(settingView)
+    SettingView
+
+  serializeSettings: ->
+    title: @projectTitle.getText()
+    paths: @getPathsFromSubviews()
+    settings: @getSettingsFromSubviews()
+
+  getPathsFromSubviews: ->
+    view.pathField.getText() for view in @pathViews
+
+  getSettingsFromSubviews: ->
+    settings = {}
+    for view in @settingViews
+      settingName = view.settingNameEditor.getText()
+      settingValue = view.settingValueEditor.getText()
+      settings[settingName] = settingValue if settingName? && settingValue?
+    settings

--- a/lib/settings/settings-view.coffee
+++ b/lib/settings/settings-view.coffee
@@ -1,0 +1,44 @@
+{$, ScrollView} = require 'atom'
+ProjectView = require './project-view'
+CSON = null
+
+module.exports =
+class SettingsView extends ScrollView
+  @projectManager: null
+
+  @content: ->
+    @div class: 'project-manager-settings-view  pane-item', =>
+      @div class: 'panel', =>
+        @div class: 'panel-heading', =>
+          @h1 'Edit Projects'
+        @div class: 'panel-body', outlet: 'projectsList'
+
+  getTitle: -> 'Project Manager Settings'
+
+  initialize: ({@projectManager})->
+    super
+    @projectViews = []
+    @loadProjects()
+    @on 'keyup', =>
+      @saveProjects()
+      true
+
+  loadProjects: () ->
+    CSON = require 'season'
+    CSON.readFile @projectManager.file(), (error, data) =>
+      for title, project of data
+        @appendProject(title: title, project: project)
+
+  appendProject: (options) ->
+    projectView = new ProjectView(options)
+    @projectViews.push(projectView)
+    @projectsList.append(projectView)
+
+  saveProjects: () ->
+    projectData = {}
+    for projectView in @projectViews
+      data = projectView.serializeSettings()
+      projectData[data.title] = data
+
+    CSON.writeFile @projectManager.file(), projectData, (error, data) =>
+      @projectManager.loadSettings()

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "season": "1.x"
+    "season": "1.x",
+    "underscore-plus": "1.5.1"
   }
 }

--- a/stylesheets/project-manager.less
+++ b/stylesheets/project-manager.less
@@ -12,3 +12,41 @@
   margin-bottom: 4px;
   font-size: 12px;
 }
+
+.project-manager-settings-view {
+  -webkit-flex: 1;
+  -webkit-flex-flow: column;
+  display: -webkit-flex;
+  position: relative;
+  overflow-y: auto;
+
+  .panel-heading {
+    color: white;
+  }
+}
+
+.project-manager-settings-project-view {
+  + .project-manager-settings-project-view {
+    margin-top: 10px;
+  }
+
+  .project-settings-panel {
+    margin-top: 10px;
+    margin-bottom: 10px;
+
+    .panel-body {
+      background: #fcfcfc;
+
+    }
+
+    .row {
+      + .row {
+        margin-top: 8px;
+      }
+    }
+
+    .add-project-setting {
+      margin-top: 8px
+    }
+  }
+}


### PR DESCRIPTION
Thanks for writing this package! Fits my use case nicely.

This pull request builds off the existing edit settings command, adding a user interface for editing existing projects.

It includes the ability to add project-specific configuration options that override default and user defaults!

(Sorry there are no specs.. I didn't see too many and I'm just getting the hang of atom package development.)

Here's a screenshot of the 'Edit Projects' page:

![screen shot 2014-08-19 at 11 51 22 pm](https://cloud.githubusercontent.com/assets/588040/3977456/3a6dcb2c-2839-11e4-8023-0d69e7b41b25.png)
