### PR TITLE
Selectors need to be more specific

### DIFF
--- a/keymaps/project-manager.cson
+++ b/keymaps/project-manager.cson
@@ -1,8 +1,8 @@
-'.platform-darwin':
+'.platform-darwin atom-workspace atom-text-editor':
   'ctrl-cmd-p': 'project-manager:toggle'
 
-'.platform-win32':
+'.platform-win32 atom-workspace atom-text-editor':
   'ctrl-shift-alt-p': 'project-manager:toggle'
 
-'.platform-linux':
+'.platform-linux atom-workspace atom-text-editor':
   'ctrl-shift-alt-p': 'project-manager:toggle'


### PR DESCRIPTION
Atom's default binding of
````js
"atom-workspace atom-text-editor" {
    "ctrl-alt-shift-p": "editor:log-cursor-scope"
}
````
Has a more specific selector so takes precedence over the project manager's binding so it hasn't worked for me. Making the selectors more specific fixes it.