### PR TITLE
Updating to use non-deprecated calls (fixes #72)

### DIFF
--- a/keymaps/project-manager.cson
+++ b/keymaps/project-manager.cson
@@ -6,3 +6,6 @@
 
 '.platform-linux':
   'ctrl-shift-alt-p': 'project-manager:toggle'
+
+'.project-manager input':
+  'enter': 'core:confirm'

--- a/lib/project-manager-add-view.coffee
+++ b/lib/project-manager-add-view.coffee
@@ -17,7 +17,7 @@ class ProjectManagerAddView extends View
   initialize: ->
     @editor.on 'core:confirm', @confirm
     @editor.on 'core:cancel', @hide
-    @editorContainer.on 'blur', @hide
+    @editor.on 'blur', @hide
 
   cancelled: =>
     @hide()

--- a/lib/project-manager-add-view.coffee
+++ b/lib/project-manager-add-view.coffee
@@ -1,4 +1,4 @@
-{View, EditorView} = require 'atom'
+{View} = require 'atom-space-pen-views'
 path = require 'path'
 
 module.exports =
@@ -6,43 +6,45 @@ class ProjectManagerAddView extends View
   projectManager: null
 
   @content: ->
-    @div class: 'project-manager overlay from-top', =>
+    @div class: 'project-manager', =>
       @div class: 'editor-container', outlet: 'editorContainer', =>
-        @subview 'editor',
-          new EditorView(mini: true, placeholderText: 'Project title')
+        @div =>
+          @input outlet:'editor', class:'native-key-bindings', placeholderText: 'Project title'
         @div =>
           @span 'Path: '
           @span class: 'text-highlight', atom.project?.getPath()
 
   initialize: ->
-    basename = path.basename(atom.project.getPath())
-    @editor.setText(basename)
-    range = [[0], [basename.length]]
-    @editor.getEditor().setSelectedBufferRange(range)
-
-  handleEvents: ->
     @editor.on 'core:confirm', @confirm
-    @editor.on 'core:cancel', @remove
-    @editor.find('input').on 'blur', @remove
+    @editor.on 'core:cancel', @hide
+    @editorContainer.on 'blur', @hide
 
-  focus: =>
-    @removeClass('hidden')
-    @editorContainer.find('.editor').focus()
+  cancelled: =>
+    @hide()
 
   confirm: =>
     project =
-      title: @editor.getText()
+      title: @editor.val()
       paths: [atom.project?.getPath()]
 
     @projectManager.addProject(project) if project.title
-    @remove() if project.title
+    @hide() if project.title
 
-  remove: =>
-    atom.workspaceView.focus() if atom.workspaceView?
-    @addClass('hidden')
+  hide: =>
+    atom.commands.dispatch(atom.views.getView(atom.workspace), 'focus');
+    @panel.hide()
+
+  show: =>
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+    basename = path.basename(atom.project.getPath())
+    @editor.val(basename)
+    @editor.focus()
+    @editor.select()
 
   toggle: (projectManager) ->
     @projectManager = projectManager
-    atom.workspaceView.append(@)
-    @focus()
-    @handleEvents()
+    if @panel?.isVisible()
+      @hide()
+    else
+      @show()

--- a/lib/project-manager.coffee
+++ b/lib/project-manager.coffee
@@ -1,4 +1,6 @@
 fs = require 'fs'
+ProjectManagerAddView = require './project-manager-add-view'
+ProjectManagerView = require './project-manager-view'
 
 module.exports =
   config:
@@ -51,7 +53,7 @@ module.exports =
         @createProjectManagerAddView(state).toggle(@)
 
       'project-manager:edit-projects': =>
-        atom.workspaceView.open @file()
+        atom.workspace.open @file()
 
       'project-manager:reload-project-settings': =>
         @loadCurrentProject()
@@ -153,12 +155,10 @@ module.exports =
 
   createProjectManagerView: (state) ->
     unless @projectManagerView?
-      ProjectManagerView = require './project-manager-view'
       @projectManagerView = new ProjectManagerView()
     @projectManagerView
 
   createProjectManagerAddView: (state) ->
     unless @projectManagerAddView?
-      ProjectManagerAddView = require './project-manager-add-view'
       @projectManagerAddView = new ProjectManagerAddView()
     @projectManagerAddView

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
+    "atom-space-pen-views": "^2.0.3",
     "season": "1.x",
     "underscore-plus": "1.5.1"
   }

--- a/spec/project-manager-spec.coffee
+++ b/spec/project-manager-spec.coffee
@@ -1,5 +1,6 @@
+{$} = require 'atom-space-pen-views'
 ProjectManager = require '../lib/project-manager'
-{WorkspaceView} = require 'atom'
+workspaceElement = null
 fs = require 'fs'
 
 describe "ProjectManager", ->
@@ -8,22 +9,24 @@ describe "ProjectManager", ->
   describe "Toggle Project Manager", ->
 
     beforeEach ->
+      workspaceElement = atom.views.getView(atom.workspace)
+      jasmine.attachToDOM(workspaceElement)
       ProjectManager.projectManagerView = null
-      atom.workspaceView = new WorkspaceView
       @settingsFile = "#{__dirname}/projects.test.cson"
       spyOn(ProjectManager, 'file').andCallFake => @settingsFile
       waitsForPromise -> atom.packages.activatePackage('project-manager')
 
     it "Shows the Project Viewer", ->
-      atom.workspaceView.trigger 'project-manager:toggle'
-      list = atom.workspaceView.find('.project-manager .list-group li')
+      atom.commands.dispatch workspaceElement, 'project-manager:toggle'
+      list = $(workspaceElement).find('.project-manager .list-group li')
       expect(list.length).toBe 1
       expect(list.first().find('.primary-line').text()).toBe 'Test01'
 
   describe "Initiating Project Manager", ->
 
     beforeEach ->
-      atom.workspaceView = new WorkspaceView
+      workspaceElement = atom.views.getView(atom.workspace)
+      jasmine.attachToDOM(workspaceElement)
       @settingsFile = "#{__dirname}/projects.test.cson"
       spyOn(ProjectManager, 'file').andCallFake => @settingsFile
       waitsForPromise -> atom.packages.activatePackage('project-manager')
@@ -51,7 +54,8 @@ describe "ProjectManager", ->
         @projects = data
         @projects.Test01.paths = [__dirname]
       ProjectManager.projectManagerView = null
-      atom.workspaceView = new WorkspaceView
+      workspaceElement = atom.views.getView(atom.workspace)
+      jasmine.attachToDOM(workspaceElement)
       spyOn(ProjectManager, 'file').andCallFake => @settingsFile
       spyOn(ProjectManager, 'getCurrentProject').andCallFake => @projects.Test01
       waitsForPromise -> atom.packages.activatePackage('project-manager')

--- a/styles/project-manager.less
+++ b/styles/project-manager.less
@@ -8,6 +8,8 @@
 
 .project-manager {}
 
+.project-manager input { width: 100%; }
+
 .project-manager-list-group {
   color: @text-color-subtle;
   text-shadow: none;


### PR DESCRIPTION
I used this upgrade guide https://atom.io/docs/v0.174.0/upgrading/upgrading-your-package -- biggest changes are probably reworking the dom attach/detach into modal dialogs and implementing related methods.  Next to that, switching from an EditorView to a regular input in the add-view.