### PR TITLE
Open multiple paths in the same window as separate root folders

### DIFF
--- a/lib/project-manager.coffee
+++ b/lib/project-manager.coffee
@@ -147,9 +147,7 @@ module.exports =
         atom.notifications?.addError errorMessage
 
   openProject: (project) ->
-    atom.open options =
-      pathsToOpen: project.paths
-      devMode: project.devMode
+    atom.project.setPaths project.paths
 
   createProjectManagerView: (state) ->
     unless @projectManagerView?


### PR DESCRIPTION
I changed openProject to open the given paths in the current window, by overwriting the currently opened folders. Before this change, if one would open multiple root folders and then save the project, loading the project would cause all paths to be loaded in separate windows. With my change, no new window is opened and all saved paths are properly loaded as root folders.

Unfortunately, I couldn't figure out how to preserve the devMode functionality of openProject. I also couldn't figure out how to open a new window and then set the saved project folders on that new window. This would make it more in line with the behaviour that is currently exhibited.

My Coffeescript / Atom dev knowledge is very limited, but maybe you could provide some pointers on how to achieve the two points I currently miss: devMode and opening a new window instead of replacing the current.