### PR TITLE
Fixes #113

### DIFF
--- a/lib/project-manager-view.coffee
+++ b/lib/project-manager-view.coffee
@@ -62,7 +62,7 @@ class ProjectManagerView extends SelectListView
       unless error
         projects = []
         for title, project of currentProjects
-          if project.template?
+          if project.template? and currentProjects[project.template]?
             project = _.deepExtend(project, currentProjects[project.template])
           projects.push(project) if project.paths?
 


### PR DESCRIPTION
I was also having this issue, it happens when a project has a template defined such as 'some-template', but for whatever reason that template does not exist. In my case it was because I'd often edit the config file manually and at some point created a typo. In any case, this commit will just skip trying to apply the template if it can't find it.