### PR TITLE
Add Support for Scoped Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ The formatting should be as follows:
   'editor.tabLength': 2
   'project-manager.showPath': true
 ```
+
+Similiarly to `config.cson`, scoped settings are also supported. This allows for grammar specific settings:
+```
+'settings':
+  '*':
+    editor:
+      tabLength: 2
+    'project-manager.showPath': true
+  '.source.gfm':
+    editor:
+      tabLength: 4
+      preferredLineLength: 85
+```
 The settings will be updated on change, but can also manually be done from the command palette with **Project Manager: Reload Project Settings**
 
 ### `devMode:`

--- a/lib/settings.coffee
+++ b/lib/settings.coffee
@@ -10,12 +10,29 @@ module.exports =
       else
         @flatten root, dict[key], dotPath
 
-  enable: (settings) ->
+  resetUserSettings: (settings, scope) ->
     _ = require 'underscore-plus'
     flatSettings = {}
+    options = if scope then {scopeSelector: scope} else {}
+
     @flatten flatSettings, settings
     for setting, value of flatSettings
       if _.isArray value
-        currentValue = atom.config.get setting
+        valueOptions = if scope then {scope: scope} else {}
+        currentValue = atom.config.get setting, valueOptions
         value = _.union currentValue, value
-      atom.config.setRawValue setting, value
+      atom.config.set setting, value, options
+
+  enable: (settings) ->
+    if settings.global?
+      settings['*'] = settings.global
+      delete settings.global
+
+    if settings['*']?
+      scopedSettings = settings
+      settings = settings['*']
+      delete scopedSettings['*']
+
+      @resetUserSettings setting, scope for scope, setting of scopedSettings
+
+    @resetUserSettings settings

--- a/spec/projects.test.cson
+++ b/spec/projects.test.cson
@@ -12,3 +12,17 @@
         'test2'
         'test3'
       ]
+'Test02':
+  'title': 'Test02'
+  'paths': [
+    '/Users/'
+  ]
+  'settings':
+    '*':
+      editor:
+        tabLength: 2
+        preferredLineLength: 80
+    '.source.coffee':
+      editor:
+        tabLength: 4
+        preferredLineLength: 100


### PR DESCRIPTION
The current project-manager implementation adds all settings to the global scope. This addition includes for support for scoped configuration similar to the atom configuration file. The update function is modeled after the reciprocating function within atom core that applies scoped settings from the global configuration file. 

I've updated the tests to confirm legacy settings function as expected, and added new tests to confirm that scoped settings apply appropriately.

This addresses #94 by allowing users to specify grammar specific settings.
