### PR TITLE
fix(projects-list-view): should emmit 'did-destroy' instead of calling close()

### DIFF
--- a/lib/projects-list-view.js
+++ b/lib/projects-list-view.js
@@ -101,8 +101,7 @@ export default class ProjectsListView extends SelectListView {
 
   close() {
     if (this.panel) {
-      this.panel.destroy();
-      this.panel = null;
+      this.panel.emitter.emit('did-destroy');
     }
   }
 


### PR DESCRIPTION
The listenners should act as expected now. Fix #161 