### PR TITLE
A temporary solution to close current

### DIFF
--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -17,8 +17,7 @@ export default class ProjectManager {
       closeCurrent: {
         type: 'boolean',
         default: false,
-        description: `Currently disabled since it\'s broken.
-          Waiting for a better way to implement it.`
+        description: `Closes the current window after opening another project`
       },
       environmentSpecificProjects: {
         type: 'boolean',

--- a/lib/project.js
+++ b/lib/project.js
@@ -168,10 +168,20 @@ export default class Project {
   }
 
   open() {
+    let win = atom.getCurrentWindow(),
+        closeCurrentWindow = atom.config.get('project-manager.closeCurrent');
+
     atom.open({
+      newWindow: true,
       pathsToOpen: this.props.paths,
       devMode: this.props.devMode
     });
+
+    if (closeCurrentWindow) {
+      setTimeout(function() {
+        win.close();
+      }, 0);
+    }
   }
 
   onUpdate(callback) {


### PR DESCRIPTION
While this may not be the cleanest way of closing the current window when opening a project, it is the only way I can find to do it for the moment.

I am running Atom on Windows so can only test on there. This means it will need testing on other operating systems as well, but it has been working for me without any problems so far.

Maybe I'm thinking of this a bit too simplistically, or maybe I'm missing something when it comes to why this hasn't been used as a solution, but if it works for everyone else and the code looks ok then perhaps this could be used as a solution until the Atom API allows for a cleaner one.