### PR TITLE
Adds a check to make sure paths[i] is a string before using replace()

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -49,6 +49,10 @@ export default class DB {
         }
 
         for (let i in result.paths) {
+          if (typeof result.paths[i] !== 'string') {
+            continue;
+          }
+
           result.paths[i] = result.paths[i].replace('~', os.homedir());
         }
 


### PR DESCRIPTION
After the most recent update I started getting a `result.paths[i].replace is not a function` error.

This pull request simply checks to make sure that `paths[i]` is actually a string before using `replace()`, since there is another item in the array with a key of `unique` that is actually a `function` which it errors on.