### PR TITLE
Safety check in Project#isCurrent

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -120,7 +120,8 @@ export default class Project {
 
   isCurrent() {
     const activePath = atom.project.getPaths()[0];
-    const mainPath = this.props.paths[0] ? this.props.paths[0] : null;
+    const mainPath = (this.props && this.props.paths && this.props.paths[0])
+      ? this.props.paths[0] : null;
     if (activePath === mainPath) {
       return true;
     }


### PR DESCRIPTION
Small patch for #143 occurring after I remove a project entry from `projects.cson`. At that point, `this.props` becomes either an array of objects (rather than a single object with `paths`) or, more strangely, `false`. No idea what the underlying issue is, but this at least avoids that pesky error.