### PR TITLE
Toggle project list and stop panel leak

### DIFF
--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -38,9 +38,11 @@ export default class ProjectManager {
 
     this.disposables.add(atom.commands.add('atom-workspace', {
       'project-manager:list-projects': () => {
-        ProjectsListView = require('./projects-list-view');
-        let projectsListView = new ProjectsListView();
-        projectsListView.toggle();
+        if (!this.projectsListView) {
+          ProjectsListView = require('./projects-list-view');
+          this.projectsListView = new ProjectsListView();
+        }
+        this.projectsListView.toggle();
       },
 
       'project-manager:save-project': () => {

--- a/lib/projects-list-view.js
+++ b/lib/projects-list-view.js
@@ -111,7 +111,8 @@ export default class ProjectsListView extends SelectListView {
 
   close() {
     if (this.panel) {
-      this.panel.emitter.emit('did-destroy');
+      this.panel.destroy();
+      this.panel = null;
     }
 
     atom.workspace.getActivePane().activate();


### PR DESCRIPTION
Close modal list when executing `project-manager:list-projects` again (already open), instead of moving focus to the editor below without hiding the modal view on top.

This also stops panels (`atom.workspace.getModalPanels()`) and `projectsListView` objects from leaking.