### PR TITLE
Swap projects in the same window

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -25,6 +25,7 @@ export default class Project {
     return {
       title: '',
       paths: [],
+	  openPaths: [],
       icon: 'icon-chevron-right',
       settings: {},
       group: null,
@@ -219,20 +220,37 @@ export default class Project {
   }
 
   open() {
-    const win = atom.getCurrentWindow();
-    const closeCurrent = atom.config.get('project-manager.closeCurrent');
+	const oneWin = atom.config.get('project-manager.oneWindow');
+	if(oneWin){
+		for(path of atom.project.getPaths())
+		atom.project.removePath(path);
 
-    atom.open({
-      pathsToOpen: this.props.paths,
-      devMode: this.props.devMode,
-      newWindow: closeCurrent
-    });
+		for(path of this.props.paths)
+		atom.project.addPath(path);
 
-    if (closeCurrent) {
-      setTimeout(function () {
-        win.close();
-      }, 0);
-    }
+		var currentFiles = atom.workspace.getPanes();
+		for(var i = 0; i < currentFiles.length; i++)
+		currentFiles[i].destroy();
+
+		for(var i = 0; i < this.props.openPaths.length; i++)
+		atom.workspace.open(this.props.openPaths[i]);
+
+	} else {
+		const win = atom.getCurrentWindow();
+		const closeCurrent = atom.config.get('project-manager.closeCurrent');
+
+		atom.open({
+			pathsToOpen: this.props.paths,
+			devMode: this.props.devMode,
+			newWindow: closeCurrent
+		});
+
+		if (closeCurrent) {
+			setTimeout(function () {
+				win.close();
+			}, 0);
+		}
+	}
   }
 
   onUpdate(callback) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
       "default": false,
       "description": "Closes the current window after opening another project"
     },
+	"oneWindow": {
+      "type": "boolean",
+      "default": true,
+      "description": "Opens and closes projects in the same window. Overwrites closeCurrent"
+    },
     "environmentSpecificProjects": {
       "type": "boolean",
       "default": false


### PR DESCRIPTION
Added simple functionality for swapping projects without opening a new project every time. Made a setting called oneWindow which is enabled by default. 

Currently closes all open tabs when switching. Next functionality to be added will be remembering opened tabs when swapping projects