### PR TITLE
Make prettifyTitle optional

### DIFF
--- a/lib/save-dialog.coffee
+++ b/lib/save-dialog.coffee
@@ -10,7 +10,8 @@ class SaveDialog extends Dialog
   constructor: () ->
     firstPath = atom.project.getPaths()[0]
     title = path.basename(firstPath)
-    title = @prettifyTitle(title)
+    if atom.config.get('project-manager.prettifyTitle')
+      title = @prettifyTitle(title)
 
     super
       prompt: 'Enter name of project'

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
       "type": "boolean",
       "default": false
     },
+    "prettifyTitle": {
+      "type": "boolean",
+      "default": true
+    },
     "sortBy": {
       "type": "string",
       "description": "Default sorting is the order in which the projects are",


### PR DESCRIPTION
While the new behavior makes titles look better, it doesn't make much sense to me when dealing with e.g. npm modules.

Additionally, you may want to use the `change-case` module or equivalent to cover more cases for the prettify function. Personally, I'm just going to disable it. :wink: