### PR TITLE
Load settings when opening

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -247,6 +247,7 @@ export default class Project {
       devMode: this.props.devMode,
       newWindow: closeCurrent
     });
+    this.load();
 
     if (closeCurrent) {
       setTimeout(function () {


### PR DESCRIPTION
By default when opening a project, local settings don't apply.