### PR TITLE
bump dependancies and fix lint errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,9 +9,9 @@
     "atom": true
   },
   "rules": {
-    "global-require": 0,
-    "import/no-extraneous-dependencies": 0,
-    "import/no-unresolved": 0,
-    "import/prefer-default-import": 0
+    "global-require": 0
+  },
+  "settings": {
+    "import/core-modules": [ "atom" ]
   }
 }

--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -4,6 +4,7 @@ import { observable, autorun, computed, action } from 'mobx';
 import untildify from 'untildify';
 import tildify from 'tildify';
 import projectUtil from 'atom-project-util';
+import { each, map } from 'underscore-plus';
 import FileStore from './stores/FileStore';
 import GitStore from './stores/GitStore';
 import Settings from './Settings';
@@ -37,15 +38,15 @@ class Manager {
     });
 
     autorun(() => {
-      for (const fileProp of this.fileStore.data) {
+      each(this.fileStore.data, (fileProp) => {
         this.addProject(fileProp);
-      }
+      }, this);
     });
 
     autorun(() => {
-      for (const gitProp of this.gitStore.data) {
+      each(this.gitStore.data, (gitProp) => {
         this.addProject(gitProp);
-      }
+      }, this);
     });
 
     autorun(() => {
@@ -74,7 +75,7 @@ class Manager {
    * Props coming from file goes before any other source.
    */
   @action addProject(props) {
-    const foundProject = this.projects.find(project => {
+    const foundProject = this.projects.find((project) => {
       const projectRootPath = project.rootPath.toLowerCase();
       const propsRootPath = untildify(props.paths[0]).toLowerCase();
       return projectRootPath === propsRootPath;
@@ -128,9 +129,7 @@ class Manager {
 
   saveProjects() {
     const projects = this.projects.filter(project => project.props.source === 'file');
-    const arr = [];
-
-    for (const project of projects) {
+    const arr = map(projects, (project) => {
       const props = project.getChangedProps();
       delete props.source;
 
@@ -138,13 +137,13 @@ class Manager {
         props.paths = props.paths.map(path => tildify(path));
       }
 
-      arr.push(props);
-    }
+      return props;
+    });
 
     this.fileStore.store(arr);
   }
 
-  isProject(project) {
+  static isProject(project) {
     if (project instanceof Project) {
       return true;
     }

--- a/lib/Settings.js
+++ b/lib/Settings.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import _ from 'underscore-plus';
+import { each, isArray, isObject } from 'underscore-plus';
 
 export default class Settings {
   update(settings = {}) {
@@ -19,10 +19,7 @@ export default class Settings {
       settings = settings['*'];
       delete scopedSettings['*'];
 
-      for (const scope of Object.keys(scopedSettings)) {
-        const setting = scopedSettings[scope];
-        this.set(setting, scope);
-      }
+      each(scopedSettings, this.set, this);
     }
 
     this.set(settings);
@@ -31,31 +28,27 @@ export default class Settings {
   set(settings, scope) {
     const flatSettings = {};
     const options = scope ? { scopeSelector: scope } : {};
-    let value;
     options.save = false;
     this.flatten(flatSettings, settings);
 
-    for (const key of Object.keys(flatSettings)) {
-      value = flatSettings[key];
+    each(flatSettings, (value, key) => {
       atom.config.set(key, value, options);
-    }
+    });
   }
 
   flatten(root, dict, path) {
-    let value;
     let dotPath;
-    let isObject;
+    let valueIsObject;
 
-    for (const key of Object.keys(dict)) {
-      value = dict[key];
+    each(dict, (value, key) => {
       dotPath = path ? `${path}.${key}` : key;
-      isObject = !_.isArray(value) && _.isObject(value);
+      valueIsObject = !isArray(value) && isObject(value);
 
-      if (isObject) {
+      if (valueIsObject) {
         this.flatten(root, dict[key], dotPath);
       } else {
-        root[dotPath] = value;
+        root[dotPath] = value; // eslint-disable-line no-param-reassign
       }
-    }
+    }, this);
   }
 }

--- a/lib/stores/FileStore.js
+++ b/lib/stores/FileStore.js
@@ -4,14 +4,14 @@ import { observable, action, asFlat, transaction } from 'mobx';
 import CSON from 'season';
 import fs from 'fs';
 import os from 'os';
-import _ from 'underscore-plus';
+import { deepExtend, each } from 'underscore-plus';
 
 export default class FileStore {
   @observable data = asFlat([]);
   templates = [];
 
   constructor() {
-    fs.exists(FileStore.getPath(), exists => {
+    fs.exists(FileStore.getPath(), (exists) => {
       if (exists) {
         this.observeFile();
       } else {
@@ -58,14 +58,15 @@ export default class FileStore {
           results = [];
         }
 
-        for (let result of results) {
+        each(results, (res) => {
+          let result = res;
           const templateName = result.template || null;
 
           if (templateName) {
             const template = results.filter(props => props.title === templateName);
 
             if (template.length) {
-              result = _.deepExtend({}, template[0], result);
+              result = deepExtend({}, template[0], result);
             }
           }
 
@@ -76,12 +77,12 @@ export default class FileStore {
           } else {
             this.templates.push(result);
           }
-        }
+        }, this);
       });
     });
   }
 
-  handleError(err) {
+  static handleError(err) {
     switch (err.name) {
       case 'SyntaxError': {
         atom.notifications.addError('There is a syntax error in your projects file. Run **Project Manager: Edit Projects** to open and fix the issue.', {
@@ -98,7 +99,7 @@ export default class FileStore {
     }
   }
 
-  isProject(settings) {
+  static isProject(settings) {
     if (typeof settings.paths === 'undefined') {
       return false;
     }

--- a/lib/views/EditView.js
+++ b/lib/views/EditView.js
@@ -117,11 +117,11 @@ export default class EditView {
     return 'Save Project';
   }
 
-  getIconName() {
+  static getIconName() {
     return 'gear';
   }
 
-  getURI() {
+  static getURI() {
     return EDIT_URI;
   }
 

--- a/lib/views/projects-list-view.js
+++ b/lib/views/projects-list-view.js
@@ -2,6 +2,7 @@
 
 import { SelectListView, $$ } from 'atom-space-pen-views';
 import { autorun } from 'mobx';
+import { each } from 'underscore-plus';
 import manager from '../Manager';
 
 export default class ProjectsListView extends SelectListView {
@@ -28,33 +29,33 @@ export default class ProjectsListView extends SelectListView {
     this.error.after(infoElement);
 
     atom.commands.add(this.element, {
-      'project-manager:alt-confirm': event => {
+      'project-manager:alt-confirm': (event) => {
         this.altConfirmed();
         event.stopPropagation();
       },
     });
   }
 
-  activate() {
+  static activate() {
   }
 
-  get possibleFilterKeys() {
+  static get possibleFilterKeys() {
     return ['title', 'group', 'template'];
   }
 
-  get defaultFilterKey() {
+  static get defaultFilterKey() {
     return 'title';
   }
 
-  get sortBy() {
+  static get sortBy() {
     return atom.config.get('project-manager.sortBy');
   }
 
-  get showPath() {
+  static get showPath() {
     return atom.config.get('project-manager.showPath');
   }
 
-  get reversedConfirm() {
+  static get reversedConfirm() {
     return atom.config.get('project-manager.alwaysOpenInSameWindow');
   }
 
@@ -165,10 +166,9 @@ export default class ProjectsListView extends SelectListView {
           if (projectMissing) {
             this.div({ class: 'icon icon-alert' }, 'Path is not available');
           } else if (showPath) {
-            let path;
-            for (path of paths) {
+            each(paths, (path) => {
               this.div({ class: 'no-icon' }, path);
-            }
+            }, this);
           }
         });
       });

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "dependencies": {
     "atom-project-util": "^4.0.0",
     "atom-space-pen-views": "^2.0.3",
-    "change-case": "^2.3.1",
-    "etch": "^0.6.3",
+    "change-case": "^3.0.0",
+    "etch": "^0.8.0",
     "findit": "^2.0.0",
     "mobx": "^2.4.4",
     "season": "^5.4.1",
@@ -82,9 +82,9 @@
     }
   },
   "devDependencies": {
-    "babel-eslint": "^6.1.2",
+    "babel-eslint": "^7.0.0",
     "eslint": "^3.4.0",
-    "eslint-config-airbnb-base": "^5.0.3",
-    "eslint-plugin-import": "^1.14.0"
+    "eslint-config-airbnb-base": "^9.0.0",
+    "eslint-plugin-import": "^2.0.1"
   }
 }

--- a/spec/.eslintrc.json
+++ b/spec/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "jasmine": true
+  }
+}

--- a/spec/project-spec.js
+++ b/spec/project-spec.js
@@ -1,5 +1,3 @@
-/* global describe it expect */
-
 const Project = require('../lib/models/Project');
 
 const packagePaths = atom.packages.getPackageDirPaths();

--- a/spec/settings-spec.js
+++ b/spec/settings-spec.js
@@ -1,4 +1,3 @@
-/* global describe it expect */
 
 const Settings = require('../lib/Settings');
 
@@ -31,5 +30,24 @@ describe('Settings', () => {
 
     expect(atom.config.get('foo.bar')).toBe('baz');
     expect(atom.config.get('foo.bar', { scope: ['.js.source'] })).toBe('not-baz');
+  });
+
+  it('loads settings with duplicate keys', () => {
+    const config = {
+      foo: {
+        bar: {
+          baz: 'overwritten',
+          boo: 'not-duplicate',
+        },
+      },
+      'foo.bar': {
+        baz: 'duplicate',
+      },
+    };
+
+    settings.load(config);
+
+    expect(atom.config.get('foo.bar.boo')).toBe('not-duplicate');
+    expect(atom.config.get('foo.bar.baz')).toBe('duplicate');
   });
 });


### PR DESCRIPTION
I noticed travis is failing on master as a result of lint errors. So I've bumped the dependancies and fixed the lint errors as a result.

I also noticed in the settings test that flatten was overwriting keys, so I added a test to specifically document that behaviour.

I'm not a big fan of underscore, but I noticed it was being used already. Some of those `each` usages could probably be changed to use `forEach`. That or turn of the [`no-restricted-syntax`](http://eslint.org/docs/rules/no-restricted-syntax) 😃 