### PR TITLE
alias Project

### DIFF
--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -105,7 +105,7 @@ export class Manager {
 
   static open(project, openInSameWindow = false) {
     if (Manager.isProject(project)) {
-      const { devMode } = project.getProps();
+      const { devMode, alias } = project.getProps();
 
       if (openInSameWindow) {
         projectUtil.switch(project.paths);
@@ -114,8 +114,32 @@ export class Manager {
           devMode,
           pathsToOpen: project.paths,
         });
+        if (alias) {
+          Manager.renameProject(alias);
+        }
       }
     }
+  }
+
+  static renameProject(alias) {
+    setTimeout(function () {
+      const projects = Array.from(document.querySelectorAll(".project-root-header .name"));
+      projects.every(function (projectName) {
+        const projectPath = projectName.dataset.path;
+        if (alias[projectPath]) {
+          projectName.innerHTML = alias[projectPath];
+        }
+        return true;
+      });
+    }, 500);
+  }
+
+  mergeProjectAlias(projectPath, projectAlias) {
+    const { alias } = this.activeProject.getProps();
+    alias[projectPath] = projectAlias;
+    this.activeProject.updateProps({ alias });
+    this.saveProjects();
+    Manager.renameProject(alias);
   }
 
   saveProject(props) {
@@ -137,7 +161,6 @@ export class Manager {
       if (atom.config.get('project-manager.savePathsRelativeToHome')) {
         props.paths = props.paths.map(path => tildify(path));
       }
-
       return props;
     });
 

--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -122,12 +122,13 @@ export class Manager {
   }
 
   static renameProject(alias) {
-    setTimeout(function () {
-      const projects = Array.from(document.querySelectorAll(".project-root-header .name"));
-      projects.every(function (projectName) {
+    setTimeout(() => {
+      const projects = Array.from(document.querySelectorAll('.project-root-header .name'));
+      projects.every((projectName) => {
+        const nameLabel = projectName;
         const projectPath = projectName.dataset.path;
         if (alias[projectPath]) {
-          projectName.innerHTML = alias[projectPath];
+          nameLabel.innerHTML = alias[projectPath];
         }
         return true;
       });

--- a/lib/models/Project.js
+++ b/lib/models/Project.js
@@ -33,6 +33,10 @@ export default class Project {
     return this.props.source;
   }
 
+  @computed get alias() {
+    return this.props.alias;
+  }
+
   @computed get lastModified() {
     let mtime = new Date(0);
     if (this.stats) {
@@ -62,6 +66,7 @@ export default class Project {
       devMode: false,
       template: null,
       source: null,
+      alias: {},
     };
   }
 

--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -54,7 +54,7 @@ export function activate() {
       manager.fetchProjects();
     },
     'project-manager:rename': (event) => {
-      const path = event.target.querySelector('.name').dataset.path;
+      const path = event.target.parentElement.querySelector('.name').dataset.path;
       (new RenameView({
         callback: (text) => {
           manager.mergeProjectAlias(path, text);

--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -7,7 +7,6 @@ import { SAVE_URI, EDIT_URI } from './views/view-uri';
 
 let disposables = null;
 let projectsListView = null;
-let renameView = null;
 let FileStore = null;
 const RenameView = require('./views/projects-rename-view');
 
@@ -54,13 +53,13 @@ export function activate() {
     'project-manager:update-projects': () => {
       manager.fetchProjects();
     },
-    'project-manager:rename': function (event) {
-      let path = event.target.querySelector('.name').dataset.path;
+    'project-manager:rename': (event) => {
+      const path = event.target.querySelector('.name').dataset.path;
       (new RenameView({
-        callback: function (text) {
+        callback: (text) => {
           manager.mergeProjectAlias(path, text);
-        }
-      })).attach()
+        },
+      })).attach();
     },
   }));
 }

--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -7,7 +7,9 @@ import { SAVE_URI, EDIT_URI } from './views/view-uri';
 
 let disposables = null;
 let projectsListView = null;
+let renameView = null;
 let FileStore = null;
+const RenameView = require('./views/projects-rename-view');
 
 export function editComponent() {
   const EditView = require('./views/EditView');
@@ -51,6 +53,14 @@ export function activate() {
     },
     'project-manager:update-projects': () => {
       manager.fetchProjects();
+    },
+    'project-manager:rename': function (event) {
+      let path = event.target.querySelector('.name').dataset.path;
+      (new RenameView({
+        callback: function (text) {
+          manager.mergeProjectAlias(path, text);
+        }
+      })).attach()
     },
   }));
 }

--- a/lib/views/projects-rename-view.js
+++ b/lib/views/projects-rename-view.js
@@ -1,0 +1,129 @@
+const { TextEditor } = require('atom');
+
+const defaultValidator = (text) => {
+  if (text.trim().length === 0) {
+    return 'required';
+  }
+  return null;
+};
+
+module.exports = class RenameView {
+  constructor(options = {}) {
+    this.callback = options.callback;
+
+    this.miniEditor = this.buildMiniEditor(options);
+    this.message = this.buildMessage(options);
+    if (options.labelText) {
+      this.label = this.buildLabel(options);
+    }
+    this.element = this.buildElement(options);
+
+    this.validator = options.validator ? options.validator : defaultValidator;
+    this.miniEditor.onDidChange(() => {
+      this.message.textContent = this.validator(this.miniEditor.getText());
+    });
+
+    atom.commands.add(this.element, {
+      'core:confirm': this.confirm.bind(this),
+      'core:cancel': this.close.bind(this),
+    });
+  }
+
+  attach() {
+    this.storeFocusedElement();
+    this.panel = atom.workspace.addModalPanel({ item: this });
+    this.miniEditor.element.focus();
+    this.miniEditor.scrollToCursorPosition();
+  }
+
+  confirm() {
+    const text = this.miniEditor.getText();
+    const error = this.validator(text);
+    if (error) {
+      this.message.textContent = error;
+      return;
+    }
+
+    if (this.callback) {
+      this.callback(text);
+    }
+    this.close();
+  }
+
+  close() {
+    this.miniEditor.setText('');
+    if (this.panel) {
+      this.panel.destroy();
+      this.panel = null;
+    }
+
+    if (this.miniEditor.element.hasFocus()) {
+      this.restoreFocus();
+    }
+  }
+
+  storeFocusedElement() {
+    this.previouslyFocusedElement = document.activeElement;
+    return this.previouslyFocusedElement;
+  }
+
+  restoreFocus() {
+    if (this.previouslyFocusedElement && this.previouslyFocusedElement.parentElement) {
+      this.previouslyFocusedElement.focus();
+      return;
+    }
+    atom.views.getView(atom.workspace).focus();
+  }
+
+  buildMiniEditor({ defaultText, textPattern, selectedRange }) {
+    const miniEditor = new TextEditor({ mini: true });
+    miniEditor.element.addEventListener('blur', this.close.bind(this));
+
+    if (defaultText) {
+      miniEditor.setText(defaultText);
+      if (selectedRange) {
+        miniEditor.setSelectedBufferRange(selectedRange);
+      }
+    }
+
+    if (textPattern) {
+      miniEditor.onWillInsertText(({ cancel, text }) => {
+        if (!text.match(textPattern)) {
+          cancel();
+        }
+      });
+    }
+
+    return miniEditor;
+  }
+
+  buildLabel({ labelText, labelClass }) {
+    const label = document.createElement('label');
+    label.textContent = labelText;
+    if (labelClass) {
+      label.classList.add(labelClass);
+    }
+
+    return label;
+  }
+
+  buildMessage() {
+    const message = document.createElement('div');
+    message.classList.add('message');
+    return message;
+  }
+
+  buildElement({ elementClass }) {
+    const element = document.createElement('div');
+    if (elementClass) {
+      element.classList.add(elementClass);
+    }
+    if (this.label) {
+      element.appendChild(this.label);
+    }
+    element.appendChild(this.miniEditor.element);
+    element.appendChild(this.message);
+
+    return element;
+  }
+};

--- a/lib/views/projects-rename-view.js
+++ b/lib/views/projects-rename-view.js
@@ -12,9 +12,9 @@ module.exports = class RenameView {
     this.callback = options.callback;
 
     this.miniEditor = this.buildMiniEditor(options);
-    this.message = this.buildMessage(options);
+    this.message = RenameView.buildMessage(options);
     if (options.labelText) {
-      this.label = this.buildLabel(options);
+      this.label = RenameView.buildLabel(options);
     }
     this.element = this.buildElement(options);
 
@@ -97,7 +97,7 @@ module.exports = class RenameView {
     return miniEditor;
   }
 
-  buildLabel({ labelText, labelClass }) {
+  static buildLabel({ labelText, labelClass }) {
     const label = document.createElement('label');
     label.textContent = labelText;
     if (labelClass) {
@@ -107,7 +107,7 @@ module.exports = class RenameView {
     return label;
   }
 
-  buildMessage() {
+  static buildMessage() {
     const message = document.createElement('div');
     message.classList.add('message');
     return message;

--- a/menus/project-manager.cson
+++ b/menus/project-manager.cson
@@ -28,3 +28,10 @@
     ]
   }
 ]
+'context-menu':
+  ".project-root-header": [
+      {
+        "label": "Project Manager:Rename",
+        "command": "project-manager:rename"
+      }
+    ]

--- a/menus/project-manager.cson
+++ b/menus/project-manager.cson
@@ -31,7 +31,7 @@
 'context-menu':
   ".project-root-header": [
       {
-        "label": "Project Manager:Rename",
+        "label": "Project Manager: alias Project",
         "command": "project-manager:rename"
       }
     ]


### PR DESCRIPTION
a solution for #99.

Project-alias is also good, but it get problem for me.
Project-alias not working when we have 2 project with the same name.
for example: there is two [src] folder, and one is alias to [customer-src] and another one is alias to [user-src], then we just get the first one work, the second one is not work.
and also, project-alias has some small bug when we have the same folder in two different projects...

so, here is my solution.
I add an alias object for every Project, when Project opened, atom will rename the project-name with the alias object。
and then, we can alias the project from context-menu.

for some details, I did next things:
1, add alias property to models/Project
2, add 2 method to Manager,
Manager.renameProject is for atom to rename the project label.
Manager. mergeProjectAlias is for atom to save the alias.
3, add a [Rename View] to let user define the alias. just a textedit View.
and the view source is from https://www.npmjs.com/package/@aki77/atom-input-dialog
4, add a commad [Project Manager: alias Project] to show the [Rename View]

Thank you for your awesome work, The Project Manager is help me a lot.
