### PR TITLE
return Disposables on consumed functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,22 +74,24 @@ function consumeProjectManager({ getProjects, getProject, saveProject, openProje
   /**
    * Get an array containing all projects.
    * The callback will be run each time a project is added.
+   * Returns a Disposable.
    */
-  getProjects(projects => {
+  disposables.add( getProjects(projects => {
     // Do something with the projects.
-  });
+  }));
 
   /**
    * Get the currently active project.
    * The callback will be run whenever the active project changes.
+   * Returns a Disposable.
    */
-  getProject(project => {
+  disposables.add( getProject(project => {
     if (project) {
       // We have an active project.
     } else {
       // Project is either not loaded yet, or there is no project saved.
     }
-  });
+  }));
 
   /**
    * Can take either a project recieved from getProjects/getProject or

--- a/lib/project-manager.js
+++ b/lib/project-manager.js
@@ -1,7 +1,7 @@
 'use babel';
 
 import { autorun } from 'mobx';
-import { CompositeDisposable } from 'atom';
+import { CompositeDisposable, Disposable } from 'atom';
 import manager from './Manager';
 import { SAVE_URI, EDIT_URI } from './views/view-uri';
 
@@ -62,13 +62,21 @@ export function deactivate() {
 export function provideProjects() {
   return {
     getProjects: (callback) => {
-      autorun(() => {
+      const disposer = autorun(() => {
         callback(manager.projects);
+      });
+
+      return new Disposable(() => {
+        disposer();
       });
     },
     getProject: (callback) => {
-      autorun(() => {
+      const disposer = autorun(() => {
         callback(manager.activeProject);
+      });
+
+      return new Disposable(() => {
+        disposer();
       });
     },
     saveProject: (project) => {


### PR DESCRIPTION
This is to stop the consumed `get` functions from being called

```js
function consumeProjectManager({ getProjects } => {
    disposable = getProjects((projects) => {
        console.log(projects);
    }));

    // projects will be logged whenever a new project is added.

...

    disposable.dispose();

    // projects will not be logged anymore whenever a new project is added.
});

```