### PR TITLE
Fix open in new window

### DIFF
--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -113,6 +113,7 @@ export class Manager {
         atom.open({
           devMode,
           pathsToOpen: project.paths,
+          newWindow: true,
         });
       }
     }


### PR DESCRIPTION
Atom 1.37 beta opens the selected project in the same window by default because of https://github.com/atom/atom/pull/19136