### PR TITLE
Remove newWindow flag, allow Atom to decide window

### DIFF
--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -113,7 +113,6 @@ export class Manager {
         atom.open({
           devMode,
           pathsToOpen: project.paths,
-          newWindow: true,
         });
       }
     }


### PR DESCRIPTION
Remove the new window flag which causes Atom to always use a new window. Allow Atom to intelligently decide which window to reuse or open new.

See issue https://github.com/danielbrodin/atom-project-manager/issues/395