### PR TITLE
Last Opened Sort Option

### DIFF
--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -107,7 +107,8 @@ export class Manager {
     if (Manager.isProject(project)) {
       const { devMode } = project.getProps();
 
-      project.lastOpened = Date.now();
+      project.setLastOpened(Date.now());
+      saveProject(project);
 
       if (openInSameWindow) {
         projectUtil.switch(project.paths);

--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -81,6 +81,8 @@ export class Manager {
       return projectRootPath === propsRootPath;
     });
 
+    props.lastModified = Date.now()
+
     if (!foundProject) {
       const newProject = new Project(props);
       this.projects.push(newProject);
@@ -107,7 +109,8 @@ export class Manager {
     if (Manager.isProject(project)) {
       const { devMode } = project.getProps();
 
-      project.lastOpened = Date.now();
+      project.setLastOpened(Date.now());
+      saveProject(project);
 
       if (openInSameWindow) {
         projectUtil.switch(project.paths);

--- a/lib/Manager.js
+++ b/lib/Manager.js
@@ -107,6 +107,8 @@ export class Manager {
     if (Manager.isProject(project)) {
       const { devMode } = project.getProps();
 
+      project.lastOpened = Date.now();
+
       if (openInSameWindow) {
         projectUtil.switch(project.paths);
       } else {

--- a/lib/models/Project.js
+++ b/lib/models/Project.js
@@ -8,7 +8,6 @@ import CSON from 'season';
 export default class Project {
   @observable props = {}
   @observable stats = null;
-  @observable lastOpened = 0;
 
   @computed get title() {
     return this.props.title;
@@ -35,12 +34,11 @@ export default class Project {
   }
 
   @computed get lastModified() {
-    let mtime = new Date(0);
-    if (this.stats) {
-      mtime = this.stats.mtime;
-    }
+    return this.props.lastModified
+  }
 
-    return mtime;
+  @computed get lastOpened() {
+    return this.props.lastOpened
   }
 
   @computed get isCurrent() {
@@ -112,6 +110,10 @@ export default class Project {
         this.stats = stats;
       }
     });
+  }
+
+  @action setLastOpened(lastOpenedTime) {
+    this.props.lastOpened = lastOpenedTime
   }
 
   /**

--- a/lib/models/Project.js
+++ b/lib/models/Project.js
@@ -8,7 +8,6 @@ import CSON from 'season';
 export default class Project {
   @observable props = {}
   @observable stats = null;
-  @observable lastOpened = 0;
 
   @computed get title() {
     return this.props.title;
@@ -41,6 +40,10 @@ export default class Project {
     }
 
     return mtime;
+  }
+  
+  @computed get lastOpened() {
+    return this.props.lastOpened
   }
 
   @computed get isCurrent() {
@@ -112,6 +115,10 @@ export default class Project {
         this.stats = stats;
       }
     });
+  }
+
+  @action setLastOpened(lastOpenedTime) {
+    this.props.lastOpened = lastOpenedTime
   }
 
   /**

--- a/lib/models/Project.js
+++ b/lib/models/Project.js
@@ -8,6 +8,7 @@ import CSON from 'season';
 export default class Project {
   @observable props = {}
   @observable stats = null;
+  @observable lastOpened = 0;
 
   @computed get title() {
     return this.props.title;
@@ -63,6 +64,7 @@ export default class Project {
       devMode: false,
       template: null,
       source: null,
+      lastOpened: Date.now()
     };
   }
 

--- a/lib/views/projects-list-view.js
+++ b/lib/views/projects-list-view.js
@@ -194,6 +194,13 @@ export default class ProjectsListView extends SelectListView {
 
         return aModified > bModified ? -1 : 1;
       });
+    } else if (key === 'last opened') {
+      sorted = items.sort((a, b) => {
+        const aOpened = a.lastOpened;
+        const bOpened = b.lastOpened;
+
+        return aOpened > bOpened ? -1 : 1;
+      });
     } else {
       sorted = items.sort((a, b) => {
         const aValue = (a[key] || '\uffff').toUpperCase();

--- a/lib/views/projects-list-view.js
+++ b/lib/views/projects-list-view.js
@@ -189,8 +189,8 @@ export default class ProjectsListView extends SelectListView {
       return items;
     } else if (key === 'last modified') {
       sorted = items.sort((a, b) => {
-        const aModified = a.lastModified.getTime();
-        const bModified = b.lastModified.getTime();
+        const aModified = a.lastModified;
+        const bModified = b.lastModified;
 
         return aModified > bModified ? -1 : 1;
       });


### PR DESCRIPTION
The "last opened" option sorts projects in the list view by when they were last opened, with the most recent appearing first. New projects are placed first, and existing projects are internally updated every time they are opened. In order to not cause incorrect sorting of the "last modified" property (since project files are now being updated when opened), the lastModified Project property is redefined to be an explicit prop, manually updated by the package when a project is changed.